### PR TITLE
Reviewed relationships

### DIFF
--- a/src/dot/relationships.dot
+++ b/src/dot/relationships.dot
@@ -259,5 +259,3 @@ digraph G {
 	project_glassfish -> project_yasson;
 }
 
-
-

--- a/src/dot/relationships.dot
+++ b/src/dot/relationships.dot
@@ -159,7 +159,6 @@ digraph G {
 	ejb -> jta;
 	ejb -> jms;
 	jsf -> jsp;
-	jsf -> bv;
 	jsf -> el;
 	jsf -> jstl;
 	jstl -> jsp;

--- a/src/dot/relationships.dot
+++ b/src/dot/relationships.dot
@@ -159,6 +159,9 @@ digraph G {
 	ejb -> jta;
 	ejb -> jms;
 	jsf -> jsp;
+	jsf -> bv;
+	jsf -> el;
+	jsf -> jstl;
 	jstl -> jsp;
 	jsp -> servlet;
 	jsp -> el;
@@ -166,6 +169,8 @@ digraph G {
 	jaxws -> jaf;
 	es -> jaspic;
 	cdi -> di;
+	cdi -> interceptors;
+	cdi -> el;
 
 	// Relationships between reference implementations
 	// and the specification that they implement.
@@ -182,11 +187,13 @@ digraph G {
 	project_glassfish -> jta;
 	project_glassfish -> jaspic;
 	project_glassfish -> jacc;
+	project_glassfish -> jaxr;
 	project_mojarra -> jsf;
 	project_metro -> jaxws;
 	project_metro -> jws;
 	project_metro -> saaj;
 	project_soteria -> es;
+	project_stable -> jaxrpc;
 	project_tyrus -> websocket;
 	project_weld -> cdi;
 	project_weld -> di;
@@ -251,4 +258,6 @@ digraph G {
 	project_glassfish -> project_weld;
 	project_glassfish -> project_yasson;
 }
+
+
 


### PR DESCRIPTION
@bshannon could you please review the changed relationships?

Basically:
- CDI now requires Interceptors and EL
- JSF requires Expression Language, JSP and JSTL
- GlassFish implements JAXR
- Stable APIs implements the JAX-RPC RI